### PR TITLE
Eternal storage refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ node_modules
 /flat
 /build
 /spec.json
+
+# Emacs backups
+\#*#
+.#*
+*~
+
+# Vim backups
+.*.sw[po]

--- a/contracts/Certifier.sol
+++ b/contracts/Certifier.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.5.2;
 
 import "./interfaces/IValidatorSet.sol";
-import "./eternal-storage/EternalStorage.sol";
+import "./eternal-storage/OwnedEternalStorage.sol";
 
 
-contract Certifier is EternalStorage {
+contract Certifier is OwnedEternalStorage {
 
     // ============================================== Constants =======================================================
 
@@ -15,13 +15,6 @@ contract Certifier is EternalStorage {
 
     event Confirmed(address indexed who);
     event Revoked(address indexed who);
-
-    // ============================================== Modifiers =======================================================
-
-    modifier onlyOwner {
-        require(msg.sender == addressStorage[OWNER]);
-        _;
-    }
 
     // =============================================== Setters ========================================================
 
@@ -46,6 +39,5 @@ contract Certifier is EternalStorage {
 
     // =============================================== Private ========================================================
 
-    bytes32 internal constant OWNER = keccak256("owner");
     bytes32 internal constant CERTIFIED = "certified";
 }

--- a/contracts/KeyGenHistory.sol
+++ b/contracts/KeyGenHistory.sol
@@ -1,11 +1,11 @@
 pragma solidity 0.5.2;
 
 import "./interfaces/IValidatorSet.sol";
-import "./eternal-storage/EternalStorage.sol";
+import "./eternal-storage/OwnedEternalStorage.sol";
 import "./libs/SafeMath.sol";
 
 
-contract KeyGenHistory is EternalStorage {
+contract KeyGenHistory is OwnedEternalStorage {
     using SafeMath for uint256;
 
     // ================================================ Events ========================================================
@@ -25,11 +25,6 @@ contract KeyGenHistory is EternalStorage {
     );
 
     // ============================================== Modifiers =======================================================
-
-    modifier onlyOwner() {
-        require(msg.sender == addressStorage[OWNER]);
-        _;
-    }
 
     modifier onlyValidator() {
         require(validatorSet().isValidator(msg.sender));
@@ -84,7 +79,6 @@ contract KeyGenHistory is EternalStorage {
 
     // =============================================== Private ========================================================
 
-    bytes32 internal constant OWNER = keccak256("owner");
     bytes32 internal constant VALIDATOR_SET = keccak256("validatorSet");
     bytes32 internal constant VALIDATOR_WROTE_PART = "validatorWrotePart";
 

--- a/contracts/RandomAuRa.sol
+++ b/contracts/RandomAuRa.sol
@@ -14,11 +14,6 @@ contract RandomAuRa is RandomBase, IRandomAuRa {
         _;
     }
 
-    modifier onlyOwner() {
-        require(msg.sender == addressStorage[OWNER]);
-        _;
-    }
-
     // =============================================== Setters ========================================================
 
     function commitHash(bytes32 _secretHash) external {
@@ -216,8 +211,6 @@ contract RandomAuRa is RandomBase, IRandomAuRa {
     bytes32 internal constant ALLOW_PUBLISH_SECRET = keccak256("allowPublishSecret");
     bytes32 internal constant COLLECT_ROUND_LENGTH = keccak256("collectRoundLength");
     bytes32 internal constant CURRENT_SECRET = keccak256("currentSecret");
-    bytes32 internal constant OWNER = keccak256("owner");
-
     bytes32 internal constant BLOCKS_PRODUCERS = "blocksProducers";
     bytes32 internal constant COMMITS = "commits";
     bytes32 internal constant COMMITTED_VALIDATORS = "committedValidators";

--- a/contracts/TxPermission.sol
+++ b/contracts/TxPermission.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.5.2;
 
 import "./interfaces/IValidatorSet.sol";
-import "./eternal-storage/EternalStorage.sol";
+import "./eternal-storage/OwnedEternalStorage.sol";
 
 
-contract TxPermission is EternalStorage {
+contract TxPermission is OwnedEternalStorage {
 
     // ============================================== Constants =======================================================
 
@@ -12,13 +12,6 @@ contract TxPermission is EternalStorage {
     /// Must be set before deploy.
     address public constant RANDOM_CONTRACT = address(0x3000000000000000000000000000000000000001);
     address public constant VALIDATOR_SET_CONTRACT = address(0x1000000000000000000000000000000000000001);
-
-    // ============================================== Modifiers =======================================================
-
-    modifier onlyOwner {
-        require(msg.sender == addressStorage[OWNER]);
-        _;
-    }
 
     // =============================================== Setters ========================================================
 
@@ -128,7 +121,6 @@ contract TxPermission is EternalStorage {
     // =============================================== Private ========================================================
 
     bytes32 internal constant ALLOWED_SENDERS = keccak256("allowedSenders");
-    bytes32 internal constant OWNER = keccak256("owner");
 
     /// Allowed transaction types mask
     uint32 internal constant NONE = 0;

--- a/contracts/abstracts/BlockRewardBase.sol
+++ b/contracts/abstracts/BlockRewardBase.sol
@@ -2,11 +2,11 @@ pragma solidity 0.5.2;
 
 import "../interfaces/IBlockReward.sol";
 import "../interfaces/IValidatorSet.sol";
-import "../eternal-storage/EternalStorage.sol";
+import "../eternal-storage/OwnedEternalStorage.sol";
 import "../libs/SafeMath.sol";
 
 
-contract BlockRewardBase is EternalStorage, IBlockReward {
+contract BlockRewardBase is OwnedEternalStorage, IBlockReward {
     using SafeMath for uint256;
 
     // ============================================== Constants =======================================================
@@ -28,11 +28,6 @@ contract BlockRewardBase is EternalStorage, IBlockReward {
 
     modifier onlyNativeToErcBridge {
         require(_isNativeToErcBridge(msg.sender));
-        _;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == addressStorage[OWNER]);
         _;
     }
 
@@ -223,7 +218,6 @@ contract BlockRewardBase is EternalStorage, IBlockReward {
     bytes32 internal constant EXTRA_RECEIVERS = keccak256("extraReceivers");
     bytes32 internal constant MINTED_TOTALLY = keccak256("mintedTotally");
     bytes32 internal constant NATIVE_TO_ERC_BRIDGES_ALLOWED = keccak256("nativeToErcBridgesAllowed");
-    bytes32 internal constant OWNER = keccak256("owner");
 
     bytes32 internal constant BRIDGE_AMOUNT = "bridgeAmount";
     bytes32 internal constant BRIDGE_NATIVE_FEE = "bridgeNativeFee";

--- a/contracts/abstracts/RandomBase.sol
+++ b/contracts/abstracts/RandomBase.sol
@@ -2,11 +2,11 @@ pragma solidity 0.5.2;
 
 import "../interfaces/IRandom.sol";
 import "../interfaces/IValidatorSet.sol";
-import "../eternal-storage/EternalStorage.sol";
+import "../eternal-storage/OwnedEternalStorage.sol";
 import "../libs/SafeMath.sol";
 
 
-contract RandomBase is EternalStorage, IRandom {
+contract RandomBase is OwnedEternalStorage, IRandom {
     using SafeMath for uint256;
 
     // ============================================== Constants =======================================================

--- a/contracts/abstracts/ValidatorSetBase.sol
+++ b/contracts/abstracts/ValidatorSetBase.sol
@@ -4,11 +4,11 @@ import "../interfaces/IBlockReward.sol";
 import "../interfaces/IERC20Minting.sol";
 import "../interfaces/IRandom.sol";
 import "../interfaces/IValidatorSet.sol";
-import "../eternal-storage/EternalStorage.sol";
+import "../eternal-storage/OwnedEternalStorage.sol";
 import "../libs/SafeMath.sol";
 
 
-contract ValidatorSetBase is EternalStorage, IValidatorSet {
+contract ValidatorSetBase is OwnedEternalStorage, IValidatorSet {
     using SafeMath for uint256;
 
     // TODO: add a description for each function
@@ -67,11 +67,6 @@ contract ValidatorSetBase is EternalStorage, IValidatorSet {
 
     modifier gasPriceIsValid() {
         require(tx.gasprice != 0);
-        _;
-    }
-
-    modifier onlyOwner() {
-        require(msg.sender == addressStorage[OWNER]);
         _;
     }
 
@@ -375,7 +370,6 @@ contract ValidatorSetBase is EternalStorage, IValidatorSet {
     bytes32 internal constant CURRENT_VALIDATORS = keccak256("currentValidators");
     bytes32 internal constant DELEGATOR_MIN_STAKE = keccak256("delegatorMinStake");
     bytes32 internal constant ERC20_TOKEN_CONTRACT = keccak256("erc20TokenContract");
-    bytes32 internal constant OWNER = keccak256("owner");
     bytes32 internal constant PENDING_VALIDATORS = keccak256("pendingValidators");
     bytes32 internal constant POOLS = keccak256("pools");
     bytes32 internal constant POOLS_INACTIVE = keccak256("poolsInactive");

--- a/contracts/eternal-storage/EternalStorage.sol
+++ b/contracts/eternal-storage/EternalStorage.sol
@@ -2,17 +2,20 @@ pragma solidity 0.5.2;
 
 
 /**
- * @title EternalStorage
+ * @title Eternal Storage
  * @dev This contract holds all the necessary state variables to carry out the storage of any contract
  * and to support the upgrade functionality.
  */
 contract EternalStorage {
 
-    // Version number of the current implementation
+    /// @dev Version number of the current implementation
     uint256 internal _version;
 
-    // Address of the current implementation
+    //// @dev Address of the current implementation
     address internal _implementation;
+
+    /// @dev Address of the owner of the contract
+    address internal _owner;
 
     // Storage mappings
     mapping(bytes32 => uint256) internal uintStorage;
@@ -26,9 +29,8 @@ contract EternalStorage {
     mapping(bytes32 => uint256[]) internal uintArrayStorage;
     mapping(bytes32 => string[]) internal stringArrayStorage;
     mapping(bytes32 => address[]) internal addressArrayStorage;
-    //mapping(bytes32 => bytes[]) internal bytesArrayStorage;
+    mapping(bytes32 => bytes[]) internal bytesArrayStorage;
     mapping(bytes32 => bool[]) internal boolArrayStorage;
     mapping(bytes32 => int256[]) internal intArrayStorage;
     mapping(bytes32 => bytes32[]) internal bytes32ArrayStorage;
-
 }

--- a/contracts/eternal-storage/OwnedEternalStorage.sol
+++ b/contracts/eternal-storage/OwnedEternalStorage.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.5.2;
+
+import "./EternalStorage.sol";
+
+
+/// @title Owned Eternal Storage
+/// @dev This contract provides ownership and access control functionality.
+/// Using the `onlyOwner` modifier, a function can be restricted to being
+/// called by the owner of the contract.  The owner of a contract can
+/// irrevocably transfer ownership using the `transferOwnership` function.
+contract OwnedEternalStorage is EternalStorage {
+
+    /// @dev Access check: revert unless `msg.sender` is the owner of the contract.
+    modifier onlyOwner() {
+        require(msg.sender == _owner);
+        _;
+    }
+}


### PR DESCRIPTION
`_owner` is used in many places, and is also used by
EternalStorageProxy, so it should be an internal field, rather than
being stored in a mapping.  Also, delete mappings that are not used from
the EternalStorage contract.