### PR TITLE
Added a nominal sum to every initial validator account

### DIFF
--- a/scripts/make_spec.js
+++ b/scripts/make_spec.js
@@ -161,6 +161,12 @@ async function main() {
         balance: '0',
         constructor: await deploy.encodeABI()
     };
+    // Add initial balance to validator accounts.
+    for (let i = 0; i < initialValidators.length; i++) {
+        spec.accounts[initialValidators[i]] = {
+            balance: '1000000000000000000'
+        }
+    }
 
     console.log('Saving spec.json file ...');
     fs.writeFileSync('spec.json', JSON.stringify(spec, null, '  '));


### PR DESCRIPTION
This allows to run a Truffle migration where Truffle charges migration fees to the validator account. I added funds to every validator account because tests can be run from the perspective of any of those.

If this solution is too simplistic, the initial balances could be passed as arguments to `make_spec.js`, either from the environment or from a `json` config file.